### PR TITLE
Release 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Release Notes for Craft Query API
 
-## 3.1.2 - 2025-xx-xx
+## 3.1.2 - 2025-06-20
 - Remove authorOf query param from user, because not really doable.
+- Add CraftPageBase to auto type generation.
+- Fix caching invalidation issue with the fields() and element type property.
+- Fix missing CORS header on cached results.
 
 ## 3.1.1 - 2025-05-17
 - Fixed small indent issue on type generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release Notes for Craft Query API
 
-## 3.1.1 - 2025-xx-xx
+## 3.1.2 - 2025-xx-xx
+- Remove authorOf query param from user, because not really doable.
+
+## 3.1.1 - 2025-05-17
 - Fixed small indent issue on type generation.
 - Fixed caching issues with preview urls.
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Speeds up development in headless mode with an API that allows querying data using URL parameters.",
   "type": "craft-plugin",
   "license": "proprietary",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "support": {
     "email": "samuelreichor@gmail.com",
     "issues": "https://github.com/samuelreichor/craft-query-api/issues?state=open",

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -83,7 +83,7 @@ class DefaultController extends Controller
             ]);
 
         if (($result = Craft::$app->getCache()->get($cacheKey)) && $this->getIsCacheableRequest($request)) {
-            return $result;
+            return $this->asJson($result);
         }
 
         // Set cache duration of config and fallback to general craft cache duration
@@ -99,7 +99,7 @@ class DefaultController extends Controller
         $transformerService = new JsonTransformerService($queryService);
         $transformedData = $transformerService->executeTransform($result, $predefinedFieldHandleArr);
 
-        $finalResult = $this->asJson($queryOne ? ($transformedData[0] ?? null) : $transformedData);
+        $finalResult = $queryOne ? ($transformedData[0] ?? null) : $transformedData;
 
         [$craftDependency] = Craft::$app->getElements()->stopCollectingCacheInfo();
 
@@ -114,7 +114,7 @@ class DefaultController extends Controller
             $combinedDependency
         );
 
-        return $finalResult;
+        return $this->asJson($finalResult);
     }
 
     /**

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -61,14 +61,12 @@ class DefaultController extends Controller
         $elementType = 'entries';
         if (isset($params['elementType']) && $params['elementType']) {
             $elementType = $params['elementType'];
-            unset($params['elementType']);
         }
 
         // Transform string of field handles to array
         $predefinedFieldHandleArr = [];
         if (isset($params['fields']) && $params['fields']) {
             $predefinedFieldHandleArr = explode(',', $params['fields']);
-            unset($params['fields']);
         }
 
         // Transform all other comma seperated strings to array

--- a/src/services/ElementQueryService.php
+++ b/src/services/ElementQueryService.php
@@ -39,7 +39,7 @@ class ElementQueryService extends Component
         'addresses' => ['limit', 'id', 'status', 'offset', 'orderBy', 'search', 'addressLine1', 'addressLine2', 'addressLine3', 'locality', 'organization', 'fullName'],
         'assets' => ['limit', 'id', 'status', 'offset', 'orderBy', 'search', 'volume', 'kind', 'filename', 'site', 'siteId'],
         'entries' => ['limit', 'id', 'status', 'offset', 'orderBy', 'search', 'slug', 'uri', 'section', 'sectionId', 'postDate', 'site', 'siteId', 'level', 'type'],
-        'users' => ['limit', 'id', 'status', 'offset', 'orderBy', 'search', 'admin', 'group', 'groupId', 'authorOf', 'email', 'fullName', 'hasPhoto'],
+        'users' => ['limit', 'id', 'status', 'offset', 'orderBy', 'search', 'admin', 'group', 'groupId', 'email', 'fullName', 'hasPhoto'],
     ];
 
     /**

--- a/src/services/TypescriptService.php
+++ b/src/services/TypescriptService.php
@@ -562,6 +562,12 @@ class TypescriptService extends Component
             cpEditUrl: string
         }
         
+        export interface CraftPageBase {
+            metadata: CraftEntryMeta
+            sectionHandle: string
+            title: string
+        }
+        
         export type CraftTagMeta = {
             id: number
         }

--- a/tests/typescript/generated-schemas.ts
+++ b/tests/typescript/generated-schemas.ts
@@ -114,6 +114,12 @@ export const craftEntryMetaSchema = z.object({
   cpEditUrl: z.string(),
 });
 
+export const craftPageBaseSchema = z.object({
+  metadata: craftEntryMetaSchema,
+  sectionHandle: z.string(),
+  title: z.string(),
+});
+
 export const craftTagMetaSchema = z.object({
   id: z.number(),
 });

--- a/tests/typescript/generated-types.ts
+++ b/tests/typescript/generated-types.ts
@@ -107,6 +107,12 @@ export type CraftEntryMeta = {
     cpEditUrl: string
 }
 
+export interface CraftPageBase {
+    metadata: CraftEntryMeta
+    sectionHandle: string
+    title: string
+}
+
 export type CraftTagMeta = {
     id: number
 }


### PR DESCRIPTION
- Remove authorOf query param from user, because not really doable.
- Add CraftPageBase to auto type generation.
- Fix caching invalidation issue with the fields() and element type property.
- Fix missing CORS header on cached results.
