### PR TITLE
Release 3.2.0

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,37 @@
+name: Scheduled Link Check
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'
+
+  workflow_dispatch:
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main]
+
+    steps:
+      - name: Checkout code from ${{ matrix.branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+          args: --verbose --no-progress --exclude http://localhost:3000 './**/*.md' './**/*.html'
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release Notes for Craft Query API
 
+## 3.2.0 - 2025-07-20
+
+### Added
+
+- Added Support for the new Content Block field in Craft 5.8.0.
+- Added icon transformer to reduce response data.
+
+### Fixed
+
+- Fixes a bug in the ts generation for Entry Types. It now checks for the title field in the entry type. If there is one, the title: string type gets added.
+
 ## 3.1.2 - 2025-06-20
 - Remove authorOf query param from user, because not really doable.
 - Add CraftPageBase to auto type generation.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@
 ## Features
 
 - API to query addresses, assets, entries and users based on url parameters.
-- API for query all urls of every active page with template for prerendering.
+- API for fetching all urls of every active page with template for prerendering.
 - Automatic detection of ImagerX transforms.
 - Automatic detection of native and custom fields on all elementTypes.
-- Events to add your own Json Transformers and Element Types. 
+- Events to add your own JSON Transformers and Element Types. 
 
 ## Requirements
 
@@ -41,12 +41,13 @@ This plugin requires Craft CMS 5.0.0 or later, and PHP 8.2 or later.
 
 Visit the Craft [Query API Plugin page](https://samuelreichor.at/libraries/craft-query-api) for all documentation, guides, pricing and developer resources.
 
-## Further Resources
+## Supported Platforms
 
-- [Vue Craft CMS](https://samuelreichor.at/libraries/vue-craftcms): A package to use the query builder in Vue.
-- [Nuxt Craft CMS](https://samuelreichor.at/libraries/nuxt-craftcms): A package to use the query builder in Nuxt.
-- [JS Craft CMS API](https://samuelreichor.at/libraries/js-craftcms-api): This package brings the query builder of craft CMS into the js ecosystem. 
-You can build wrappers around it to support your framework.
+- [`@query-api/js`](https://samuelreichor.at/libraries/js-craftcms-api): Core SDK for all JavaScript Frameworks.
+- [`@query-api/vue`](https://samuelreichor.at/libraries/vue-craftcms): SDK for Vue.
+- [`@query-api/nuxt`](https://samuelreichor.at/libraries/nuxt-craftcms): SDK for Nuxt.
+- [`@query-api/react`](https://samuelreichor.at/libraries/query-api-react): SDK for React.
+- [`@query-api/next`](https://samuelreichor.at/libraries/query-api-next): SDK for Next.
 
 
 ## Support

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Speeds up development in headless mode with an API that allows querying data using URL parameters.",
   "type": "craft-plugin",
   "license": "proprietary",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "support": {
     "email": "samuelreichor@gmail.com",
     "issues": "https://github.com/samuelreichor/craft-query-api/issues?state=open",

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -271,4 +271,16 @@ class DefaultController extends Controller
 
         return true;
     }
+
+    /*    public function actionGenerateTypes()
+        {
+            $code = QueryApi::getInstance()->typescript->getTypes();
+
+            return Craft::$app->response
+                ->setStatusCode(200)
+                ->sendContentAsFile($code, 'types.d.ts', [
+                    'mimeType' => 'text/plain',
+                    'inline' => true,
+                ]);
+        }*/
 }

--- a/src/helpers/Utils.php
+++ b/src/helpers/Utils.php
@@ -7,6 +7,7 @@ use craft\fieldlayoutelements\users\PhotoField;
 use craft\fields\ButtonGroup;
 use craft\fields\Checkboxes;
 use craft\fields\Dropdown;
+use craft\fields\Icon;
 use craft\fields\MultiSelect;
 use craft\fields\RadioButtons;
 use craft\fields\Table;
@@ -69,7 +70,8 @@ class Utils
         return (property_exists($field, 'maxEntries') && $field->maxEntries === 1)
             || (property_exists($field, 'maxRelations') && $field->maxRelations === 1)
             || (property_exists($field, 'maxAddresses') && $field->maxAddresses === 1)
-            || (get_class($field) === PhotoField::class);
+            || (get_class($field) === PhotoField::class)
+            || (get_class($field) === Icon::class);
     }
 
     public static function isArrayField($field): bool

--- a/src/services/TypescriptService.php
+++ b/src/services/TypescriptService.php
@@ -4,13 +4,13 @@ namespace samuelreichoer\queryapi\services;
 
 use Craft;
 use craft\base\Component;
-use craft\base\Field;
 use craft\elements\User;
 use craft\fieldlayoutelements\addresses\AddressField;
 use craft\fieldlayoutelements\addresses\CountryCodeField;
 use craft\fieldlayoutelements\assets\AltField;
 use craft\fieldlayoutelements\BaseField;
 use craft\fieldlayoutelements\CustomField;
+use craft\fieldlayoutelements\entries\EntryTitleField;
 use craft\fieldlayoutelements\users\PhotoField;
 use craft\fields\Addresses;
 use craft\fields\Assets;
@@ -58,7 +58,6 @@ class TypescriptService extends Component
         parent::__construct();
         $this->registerCustomTypeDefinitions();
     }
-
 
     public function getTypes(): string
     {
@@ -140,6 +139,15 @@ class TypescriptService extends Component
         $tsFieldTypes = [];
         foreach ($fieldElements as $field) {
             $fieldClass = get_class($field);
+
+            // only include title type in entry types if the entry type actually has a title field.
+            if ($field instanceof EntryTitleField) {
+                // @phpstan-ignore-next-line
+                if (property_exists($fieldLayout->provider, 'hasTitleField') && !$fieldLayout->provider->hasTitleField) {
+                    continue;
+                }
+            }
+
             // only custom fields have the getField() method
             if (method_exists($field, 'getField')) {
                 $field = $field->getField();
@@ -156,7 +164,6 @@ class TypescriptService extends Component
             }
 
             $fieldHandle = $field->handle ?? $field->attribute ?? 'unknown';
-            $isSingleRelation = Utils::isSingleRelationField($field);
 
             // Check for custom type definition
             foreach ($this->customTypeDefinitions as $definition) {
@@ -385,6 +392,8 @@ class TypescriptService extends Component
             'label' => 'string',
             'selected' => 'boolean',
             'valid' => 'boolean',
+            'icon' => 'string | null',
+            'color' => 'string | null',
         ];
 
         $optionClasses = [Dropdown::class, RadioButtons::class, Checkboxes::class, MultiSelect::class, 'craft\fields\ButtonGroup'];

--- a/src/transformers/BaseTransformer.php
+++ b/src/transformers/BaseTransformer.php
@@ -15,6 +15,7 @@ use craft\fields\Categories;
 use craft\fields\Color;
 use craft\fields\Country;
 use craft\fields\Entries;
+use craft\fields\Icon;
 use craft\fields\Link;
 use craft\fields\Matrix;
 use craft\fields\Tags;
@@ -154,6 +155,7 @@ abstract class BaseTransformer extends Component
             Color::class => $this->transformColor($fieldValue),
             Country::class => $this->transformCountry($fieldValue),
             Entries::class => $this->transformEntries($fieldValue->all()),
+            Icon::class => $this->transformIcon($fieldValue),
             Matrix::class => $this->transformMatrixField($fieldValue->all()),
             Link::class => $this->transformLinks($fieldValue),
             Tags::class => $this->transformTags($fieldValue->all()),
@@ -165,7 +167,7 @@ abstract class BaseTransformer extends Component
     /**
      * Transforms a native field based on its class.
      *
-     * @param mixed  $fieldValue
+     * @param mixed $fieldValue
      * @param string $fieldClass
      * @return mixed
      */
@@ -220,7 +222,7 @@ abstract class BaseTransformer extends Component
             foreach ($block->getFieldValues() as $fieldHandle => $fieldValue) {
                 $field = $block->getFieldLayout()->getFieldByHandle($fieldHandle);
 
-                // Check if field has a limit of relations
+                // Check if the field has a limit of relations
                 $isSingleRelation = Utils::isSingleRelationField($field);
                 $fieldClass = get_class($field);
 
@@ -405,6 +407,21 @@ abstract class BaseTransformer extends Component
             'currencyCode' => $country->getCurrencyCode(),
             'timezones' => $country->getTimezones(),
         ];
+    }
+
+    /**
+     * Transforms a icon element
+     *
+     * @param mixed $icon
+     * @return array
+     */
+    protected function transformIcon(mixed $icon): array
+    {
+        if (empty($icon)) {
+            return [];
+        }
+
+        return [$icon->name];
     }
 
     /**

--- a/src/transformers/BaseTransformer.php
+++ b/src/transformers/BaseTransformer.php
@@ -153,6 +153,7 @@ abstract class BaseTransformer extends Component
             Assets::class => $this->transformAssets($fieldValue->all()),
             Categories::class => $this->transformCategories($fieldValue->all()),
             Color::class => $this->transformColor($fieldValue),
+            'craft\fields\ContentBlock' => $this->transformContentBlock($fieldValue),
             Country::class => $this->transformCountry($fieldValue),
             Entries::class => $this->transformEntries($fieldValue->all()),
             Icon::class => $this->transformIcon($fieldValue),
@@ -238,6 +239,31 @@ abstract class BaseTransformer extends Component
         }
 
         return $transformedData;
+    }
+
+    /**
+     * @throws InvalidFieldException
+     * @throws ImageTransformException
+     * @throws InvalidConfigException
+     */
+    protected function transformContentBlock(mixed $block)
+    {
+        $blockData = [];
+
+        foreach ($block->getFieldValues() as $fieldHandle => $fieldValue) {
+            $field = $block->getFieldLayout()->getFieldByHandle($fieldHandle);
+
+            $isSingleRelation = Utils::isSingleRelationField($field);
+            $fieldClass = get_class($field);
+
+            // Exclude fields in matrix blocks
+            if (in_array($fieldClass, $this->excludeFieldClasses, true)) {
+                continue;
+            }
+
+            $blockData[$fieldHandle] = $this->getTransformedCustomFieldData($isSingleRelation, $fieldValue, $fieldClass);
+        }
+        return $blockData;
     }
 
     /**

--- a/tests/typescript/generated-schemas.ts
+++ b/tests/typescript/generated-schemas.ts
@@ -179,7 +179,6 @@ export const craftAssetSchema = z.union([
 ]);
 
 export const craftEntryTypeImageTextSchema = z.object({
-  title: z.string(),
   asset: z.array(craftAssetSchema).nullable(),
   plainText: z.string().nullable(),
 });
@@ -187,7 +186,6 @@ export const craftEntryTypeImageTextSchema = z.object({
 export const dynamicHardTypeSchema = z.array(z.record(z.any()));
 
 export const craftEntryTypeLinkSchema = z.object({
-  title: z.string(),
   linkText: z.string().nullable(),
   openInNewTab: z.boolean().nullable(),
   linkField: craftLinkSchema.nullable(),
@@ -203,14 +201,12 @@ export const craftUserSchema = z.object({
 });
 
 export const craftEntryTypeAuthorSchema = z.object({
-  title: z.string(),
   selectAuthor: z.array(craftUserSchema).nullable(),
   address: z.array(craftAddressSchema).nullable(),
   linkField: craftLinkSchema.nullable(),
 });
 
 export const craftEntryTypeHyperLinkSchema = z.object({
-  title: z.string(),
   hyperField: dynamicHardTypeSchema,
 });
 
@@ -241,6 +237,8 @@ export const craftOptionDropdownSchema = z.object({
   label: z.string(),
   selected: z.boolean(),
   valid: z.boolean(),
+  icon: z.string().nullable(),
+  color: z.string().nullable(),
   value: craftOptionValueDropdownSchema,
 });
 
@@ -255,6 +253,8 @@ export const craftOptionHeadlineTagSchema = z.object({
   label: z.string(),
   selected: z.boolean(),
   valid: z.boolean(),
+  icon: z.string().nullable(),
+  color: z.string().nullable(),
   value: craftOptionValueHeadlineTagSchema,
 });
 
@@ -267,6 +267,8 @@ export const craftOptionRadioButtonsSchema = z.object({
   label: z.string(),
   selected: z.boolean(),
   valid: z.boolean(),
+  icon: z.string().nullable(),
+  color: z.string().nullable(),
   value: craftOptionValueRadioButtonsSchema,
 });
 
@@ -279,6 +281,8 @@ export const craftOptionCheckboxesSchema = z.object({
   label: z.string(),
   selected: z.boolean(),
   valid: z.boolean(),
+  icon: z.string().nullable(),
+  color: z.string().nullable(),
   value: craftOptionValueCheckboxesSchema,
 });
 
@@ -291,6 +295,8 @@ export const craftOptionMultiSelectSchema = z.object({
   label: z.string(),
   selected: z.boolean(),
   valid: z.boolean(),
+  icon: z.string().nullable(),
+  color: z.string().nullable(),
   value: craftOptionValueMultiSelectSchema,
 });
 
@@ -303,6 +309,8 @@ export const craftOptionButtonGroupSchema = z.object({
   label: z.string(),
   selected: z.boolean(),
   valid: z.boolean(),
+  icon: z.string().nullable(),
+  color: z.string().nullable(),
   value: craftOptionValueButtonGroupSchema,
 });
 
@@ -313,15 +321,62 @@ export const craftEntryTypeCtaSchema = z.object({
   entries: z.array(craftEntryRelationSchema).nullable(),
 });
 
-export const craftEntryTypeNewsTeaserSchema = z.object({
+export const craftEntryTypeHeadlineSchema = z.object({
   title: z.string(),
+  headlineTag: craftOptionHeadlineTagSchema,
+});
+
+export const craftEntryTypeNewsTeaserSchema = z.object({
   categories: z.array(craftCategoryNewsFilterSchema).nullable(),
   newsTag: z.array(craftTagSchema).nullable(),
 });
 
-export const craftEntryTypeHeadlineSchema = z.object({
+export const craftEntryTypeHomeSchema = z.object({
   title: z.string(),
-  headlineTag: craftOptionHeadlineTagSchema,
+  asset: z.array(craftAssetSchema).nullable(),
+  selectAuthor: z.array(craftUserSchema).nullable(),
+  plainText: z.string().nullable(),
+  richtext: z.string().nullable(),
+  contentBuilder: z
+    .array(
+      z.union([
+        craftEntryTypeAuthorSchema,
+        craftEntryTypeHeadlineSchema,
+        craftEntryTypeImageTextSchema,
+        craftEntryTypeNewsTeaserSchema,
+        craftEntryTypeLinkSchema,
+        craftEntryTypeHyperLinkSchema,
+      ]),
+    )
+    .nullable(),
+  cta: z.array(craftEntryTypeCtaSchema).nullable(),
+});
+
+export const craftContentBlockContentBlockSchema = z.object({
+  richtext: z.string().nullable(),
+  singleMatrix: craftEntryTypeCtaSchema.nullable(),
+  matrix: z
+    .array(
+      z.union([craftEntryTypeHeadlineSchema, craftEntryTypeImageTextSchema]),
+    )
+    .nullable(),
+});
+
+export const craftEntryTypeRelationalFieldsWithMaxSettingSchema: z.ZodObject<any, any, any> = z.object({
+            title: z.string(),
+            singleRelatedAddress: craftAddressSchema.nullable(),
+            singleRelatedAsset: craftAssetSchema.nullable(),
+            singleRelatedCategory: craftCategoryNewsFilterSchema.nullable(),
+            singleMatrix: craftEntryTypeCtaSchema.nullable(),
+            singleRelatedEntry: craftEntryRelationSchema.nullable(),
+            singleRelatedUser: craftUserSchema.nullable(),
+            matrixMaxRelations: z.lazy(() => craftEntryTypeRelationalFieldsWithMaxSettingSchema.nullable()),
+          });
+
+export const craftPageHomeSchema = craftEntryTypeHomeSchema.extend({
+  metadata: craftEntryMetaSchema,
+  title: z.string(),
+  sectionHandle: z.string(),
 });
 
 export const craftEntryTypeDefaultFieldsSchema = z.object({
@@ -332,6 +387,7 @@ export const craftEntryTypeDefaultFieldsSchema = z.object({
   categories: z.array(craftCategoryNewsFilterSchema),
   checkboxes: z.array(craftOptionCheckboxesSchema),
   color: craftColorSchema,
+  contentBlock: craftContentBlockContentBlockSchema.nullable(),
   country: craftCountrySchema,
   date: craftDateTimeSchema.nullable(),
   dropdown: craftOptionDropdownSchema.nullable(),
@@ -358,45 +414,6 @@ export const craftEntryTypeDefaultFieldsSchema = z.object({
   users: z.array(craftUserSchema).nullable(),
 });
 
-export const craftEntryTypeRelationalFieldsWithMaxSettingSchema: z.ZodObject<any, any, any> = z.object({
-            title: z.string(),
-            singleRelatedAddress: craftAddressSchema.nullable(),
-            singleRelatedAsset: craftAssetSchema.nullable(),
-            singleRelatedCategory: craftCategoryNewsFilterSchema.nullable(),
-            singleMatrix: craftEntryTypeCtaSchema.nullable(),
-            singleRelatedEntry: craftEntryRelationSchema.nullable(),
-            singleRelatedUser: craftUserSchema.nullable(),
-            matrixMaxRelations: z.lazy(() => craftEntryTypeRelationalFieldsWithMaxSettingSchema.nullable()),
-          });
-
-export const craftEntryTypeHomeSchema = z.object({
-  title: z.string(),
-  asset: z.array(craftAssetSchema).nullable(),
-  selectAuthor: z.array(craftUserSchema).nullable(),
-  plainText: z.string().nullable(),
-  richtext: z.string().nullable(),
-  contentBuilder: z
-    .array(
-      z.union([
-        craftEntryTypeAuthorSchema,
-        craftEntryTypeHeadlineSchema,
-        craftEntryTypeImageTextSchema,
-        craftEntryTypeNewsTeaserSchema,
-        craftEntryTypeLinkSchema,
-        craftEntryTypeHyperLinkSchema,
-      ]),
-    )
-    .nullable(),
-  cta: z.array(craftEntryTypeCtaSchema).nullable(),
-});
-
-export const craftPageDefaultFieldsSchema =
-  craftEntryTypeDefaultFieldsSchema.extend({
-    metadata: craftEntryMetaSchema,
-    title: z.string(),
-    sectionHandle: z.string(),
-  });
-
 export const craftPageRelationalFieldsWithMaxSettingSchema =
   craftEntryTypeRelationalFieldsWithMaxSettingSchema.extend({
     metadata: craftEntryMetaSchema,
@@ -404,8 +421,9 @@ export const craftPageRelationalFieldsWithMaxSettingSchema =
     sectionHandle: z.string(),
   });
 
-export const craftPageHomeSchema = craftEntryTypeHomeSchema.extend({
-  metadata: craftEntryMetaSchema,
-  title: z.string(),
-  sectionHandle: z.string(),
-});
+export const craftPageDefaultFieldsSchema =
+  craftEntryTypeDefaultFieldsSchema.extend({
+    metadata: craftEntryMetaSchema,
+    title: z.string(),
+    sectionHandle: z.string(),
+  });

--- a/tests/typescript/generated-types.ts
+++ b/tests/typescript/generated-types.ts
@@ -179,25 +179,21 @@ export interface CraftEntryTypeCta {
 }
 
 export interface CraftEntryTypeImageText {
-    title: string
     asset: (CraftAsset)[] | null
     plainText: string | null
 }
 
 export interface CraftEntryTypeHyperLink {
-    title: string
     hyperField: DynamicHardType
 }
 
 export interface CraftEntryTypeLink {
-    title: string
     linkText: string | null
     openInNewTab: boolean | null
     linkField: CraftLink | null
 }
 
 export interface CraftEntryTypeNewsTeaser {
-    title: string
     categories: (CraftCategoryNewsFilter)[] | null
     newsTag: (CraftTag)[] | null
 }
@@ -218,7 +214,6 @@ export interface CraftEntryTypeHeadline {
 }
 
 export interface CraftEntryTypeAuthor {
-    title: string
     selectAuthor: (CraftUser)[] | null
     address: (CraftAddress)[] | null
     linkField: CraftLink | null
@@ -232,6 +227,7 @@ export interface CraftEntryTypeDefaultFields {
     categories: (CraftCategoryNewsFilter)[]
     checkboxes: (CraftOptionCheckboxes)[]
     color: CraftColor
+    contentBlock: CraftContentBlockContentBlock | null
     country: CraftCountry
     date: CraftDateTime | null
     dropdown: CraftOptionDropdown | null
@@ -326,6 +322,8 @@ export type CraftOptionDropdown = {
     label: string
     selected: boolean
     valid: boolean
+    icon: string | null
+    color: string | null
     value: CraftOptionValueDropdown
 }
 
@@ -335,6 +333,8 @@ export type CraftOptionHeadlineTag = {
     label: string
     selected: boolean
     valid: boolean
+    icon: string | null
+    color: string | null
     value: CraftOptionValueHeadlineTag
 }
 
@@ -344,6 +344,8 @@ export type CraftOptionRadioButtons = {
     label: string
     selected: boolean
     valid: boolean
+    icon: string | null
+    color: string | null
     value: CraftOptionValueRadioButtons
 }
 
@@ -353,6 +355,8 @@ export type CraftOptionCheckboxes = {
     label: string
     selected: boolean
     valid: boolean
+    icon: string | null
+    color: string | null
     value: CraftOptionValueCheckboxes
 }
 
@@ -362,6 +366,8 @@ export type CraftOptionMultiSelect = {
     label: string
     selected: boolean
     valid: boolean
+    icon: string | null
+    color: string | null
     value: CraftOptionValueMultiSelect
 }
 
@@ -371,7 +377,18 @@ export type CraftOptionButtonGroup = {
     label: string
     selected: boolean
     valid: boolean
+    icon: string | null
+    color: string | null
     value: CraftOptionValueButtonGroup
+}
+
+
+
+// --- contentBlocks ---
+export interface CraftContentBlockContentBlock {
+    richtext: string | null
+    singleMatrix: CraftEntryTypeCta | null
+    matrix: (CraftEntryTypeHeadline | CraftEntryTypeImageText)[] | null
 }
 
 


### PR DESCRIPTION
### Added

- Added Support for the new Content Block field in Craft 5.8.0.
- Added icon transformer to reduce response data.

### Fixed

- Fixes a bug in the ts generation for Entry Types. It now checks for the title field in the entry type. If there is one, the title: string type gets added.