### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Craft Query API
 
+## 3.2.1 - 2025-09-xx
+
+### Fixed
+
+- Fix php error that can occur if fields are trashed and accessed with getFields().
+
 ## 3.2.0 - 2025-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Release Notes for Craft Query API
 
-## 3.2.1 - 2025-09-xx
+## 3.2.1 - 2025-09-07
 
 ### Fixed
 
+- Improve error handling of serialization errors that can occur with custom fields installed by modules or plugins in custom query endpoint.
 - Fix php error that can occur if fields are trashed and accessed with getFields().
 
 ## 3.2.0 - 2025-07-20

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Speeds up development in headless mode with an API that allows querying data using URL parameters.",
   "type": "craft-plugin",
   "license": "proprietary",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "support": {
     "email": "samuelreichor@gmail.com",
     "issues": "https://github.com/samuelreichor/craft-query-api/issues?state=open",

--- a/src/services/TypescriptService.php
+++ b/src/services/TypescriptService.php
@@ -5,6 +5,7 @@ namespace samuelreichoer\queryapi\services;
 use Craft;
 use craft\base\Component;
 use craft\elements\User;
+use craft\errors\FieldNotFoundException;
 use craft\fieldlayoutelements\addresses\AddressField;
 use craft\fieldlayoutelements\addresses\CountryCodeField;
 use craft\fieldlayoutelements\assets\AltField;
@@ -154,7 +155,12 @@ class TypescriptService extends Component
 
             // only custom fields have the getField() method
             if (method_exists($field, 'getField')) {
-                $field = $field->getField();
+                try {
+                    $field = $field->getField();
+                } catch (FieldNotFoundException $e) {
+                    // sometimes trashed items are still in the layout but don't exist.
+                    continue;
+                }
                 $fieldClass = get_class($field);
             }
 

--- a/src/transformers/BaseTransformer.php
+++ b/src/transformers/BaseTransformer.php
@@ -5,6 +5,7 @@ namespace samuelreichoer\queryapi\transformers;
 use Craft;
 use craft\base\Component;
 use craft\base\ElementInterface;
+use craft\errors\FieldNotFoundException;
 use craft\errors\ImageTransformException;
 use craft\errors\InvalidFieldException;
 use craft\fieldlayoutelements\BaseField;
@@ -79,7 +80,12 @@ abstract class BaseTransformer extends Component
 
             // only custom fields have the getField() method
             if (method_exists($field, 'getField')) {
-                $field = $field->getField();
+                try {
+                    $field = $field->getField();
+                } catch (FieldNotFoundException $e) {
+                    // sometimes trashed items are still in the layout but don't exist.
+                    continue;
+                }
                 $fieldClass = get_class($field);
             }
 


### PR DESCRIPTION
### Fixed

- Improve error handling of serialization errors that can occur with custom fields installed by modules or plugins in custom query endpoint.
- Fix php error that can occur if fields are trashed and accessed with getFields().