### PR TITLE
Release 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release Notes for Craft Query API
 
+## 3.5.0 - 2025-09-28
+
+### Added
+
+- Add support for `relatedTo` entry queries.
+- Add support for `andRelatedTo` entry queries.
+- Add support for `notRelated` entry queries.
+- Add support for `andNotRelatedTo` entry queries.
+- Add generated fields to custom query response and ts types.
+
+### Fixed
+- Fixes caching issues in plugin development.
+
 ## 3.4.0 - 2025-09-25
 
 ### Added
@@ -9,10 +22,10 @@
 - Add `modifyTypeByField` util, to make typing of custom fields easier.
 - Add `getFieldHandleOrAttributeForField` util, to make typing for custom fields easier.
 
-## Fixed
+### Fixed
 - Fixed ts output for fields that have an attribute but not as a public property.
 
-## Changed
+### Changed
 - Make TypeScript controller more reusable
 
 ## 3.3.0 - 2025-09-14
@@ -24,11 +37,11 @@
 - Add new `includeFullEntry()` property. If this is true, related entries through the entries field get included in the response.
 - Add new `includeFullEntry` setting. Globally disable or enable this property with the queryApi.php config.
 
-## Fixed
+### Fixed
 - Fixed an issue with the serialization error handling of nested arrays.
 - Fixed type issues of plugin settings.
 
-## Changed
+### Changed
 - Simplify matrix/content block base transformer.
 
 ## 3.2.1 - 2025-09-07

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Speeds up development in headless mode with an API that allows querying data using URL parameters.",
   "type": "craft-plugin",
   "license": "proprietary",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "support": {
     "email": "samuelreichor@gmail.com",
     "issues": "https://github.com/samuelreichor/craft-query-api/issues?state=open",

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -19,5 +19,5 @@ class Constants
     public const CACHE_TAG_GlOBAL = 'queryapi:global';
 
     // Base Transformer Settings
-    public const EXCLUDED_FIELD_HANDLES = ['nystudio107\seomatic\fields\SeoSettings'];
+    public const EXCLUDED_FIELD_CLASSES = ['nystudio107\seomatic\fields\SeoSettings'];
 }

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -88,12 +88,10 @@ class DefaultController extends Controller
                 'params' => $params,
             ]);
 
-        if (($result = Craft::$app->getCache()->get($cacheKey)) && $this->getIsCacheableRequest($request)) {
+        $duration = QueryApi::getInstance()->cache->getCacheDuration();
+        if ($duration > 0 && $this->getIsCacheableRequest($request) && ($result = Craft::$app->getCache()->get($cacheKey))) {
             return $this->asJson($result);
         }
-
-        // Set cache duration of config and fallback to general craft cache duration
-        $duration = QueryApi::getInstance()->cache->getCacheDuration();
 
         Craft::$app->getElements()->startCollectingCacheInfo();
 

--- a/src/helpers/Fields.php
+++ b/src/helpers/Fields.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace samuelreichoer\queryapi\helpers;
+
+use Craft;
+use craft\fieldlayoutelements\BaseField;
+use craft\fieldlayoutelements\CustomField;
+use craft\models\FieldLayout;
+
+class Fields
+{
+    public static function getAllFieldElementsByLayout(FieldLayout $fieldLayout): array
+    {
+        $generatedFields = method_exists($fieldLayout, 'getGeneratedFields')
+            ? $fieldLayout->getGeneratedFields()
+            : [];
+
+        $baseFields = $fieldLayout->getElementsByType(BaseField::class);
+        $customFields = $fieldLayout->getElementsByType(CustomField::class);
+
+        return array_merge($baseFields, $customFields, $generatedFields);
+    }
+
+    public static function isGeneratedField(mixed $field): bool
+    {
+        if (is_array($field) && isset($field['handle']) && isset($field['uid'])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function getGeneratedFieldHandle(array $field): string
+    {
+        if (!isset($field['handle'])) {
+            Craft::error('Cannot process array field: ' . serialize($field), 'queryApi');
+            return '';
+        }
+
+        return $field['handle'];
+    }
+
+    public static function getGeneratedFieldUid(array $field): string
+    {
+        if (!isset($field['uid'])) {
+            Craft::error('Cannot process array field: ' . serialize($field), 'queryApi');
+            return '';
+        }
+
+        return $field['uid'];
+    }
+}

--- a/src/services/TypescriptService.php
+++ b/src/services/TypescriptService.php
@@ -9,8 +9,6 @@ use craft\errors\FieldNotFoundException;
 use craft\fieldlayoutelements\addresses\AddressField;
 use craft\fieldlayoutelements\addresses\CountryCodeField;
 use craft\fieldlayoutelements\assets\AltField;
-use craft\fieldlayoutelements\BaseField;
-use craft\fieldlayoutelements\CustomField;
 use craft\fieldlayoutelements\entries\EntryTitleField;
 use craft\fieldlayoutelements\users\PhotoField;
 use craft\fields\Addresses;
@@ -45,6 +43,7 @@ use samuelreichoer\queryapi\Constants;
 use samuelreichoer\queryapi\enums\AssetMode;
 use samuelreichoer\queryapi\events\RegisterTypeDefinitionEvent;
 use samuelreichoer\queryapi\helpers\AssetHelper;
+use samuelreichoer\queryapi\helpers\Fields;
 use samuelreichoer\queryapi\helpers\Typescript;
 use samuelreichoer\queryapi\QueryApi;
 
@@ -162,9 +161,14 @@ class TypescriptService extends Component
 
     protected function getTypesByFieldLayout(FieldLayout $fieldLayout): array
     {
-        $fieldElements = array_merge($fieldLayout->getElementsByType(BaseField::class), $fieldLayout->getElementsByType(CustomField::class));
+        $fieldElements = Fields::getAllFieldElementsByLayout($fieldLayout);
         $tsFieldTypes = [];
         foreach ($fieldElements as $field) {
+            if (Fields::isGeneratedField($field)) {
+                $tsFieldTypes[Fields::getGeneratedFieldHandle($field)] = 'string';
+                continue;
+            }
+
             $fieldClass = get_class($field);
 
             // only include title type in entry types if the entry type actually has a title field.

--- a/src/services/TypescriptService.php
+++ b/src/services/TypescriptService.php
@@ -511,10 +511,10 @@ class TypescriptService extends Component
     protected function getExcludedFieldClasses(): array
     {
         if (isset(QueryApi::getInstance()->getSettings()->excludeFieldClasses)) {
-            return array_merge(Constants::EXCLUDED_FIELD_HANDLES, QueryApi::getInstance()->getSettings()->excludeFieldClasses);
+            return array_merge(Constants::EXCLUDED_FIELD_CLASSES, QueryApi::getInstance()->getSettings()->excludeFieldClasses);
         }
 
-        return Constants::EXCLUDED_FIELD_HANDLES;
+        return Constants::EXCLUDED_FIELD_CLASSES;
     }
 
     protected function handleUnknownField($field): string

--- a/src/transformers/BaseTransformer.php
+++ b/src/transformers/BaseTransformer.php
@@ -496,10 +496,10 @@ abstract class BaseTransformer extends Component
     protected function getExcludedFieldClasses(): array
     {
         if (isset(QueryApi::getInstance()->getSettings()->excludeFieldClasses)) {
-            return array_merge(Constants::EXCLUDED_FIELD_HANDLES, QueryApi::getInstance()->getSettings()->excludeFieldClasses);
+            return array_merge(Constants::EXCLUDED_FIELD_CLASSES, QueryApi::getInstance()->getSettings()->excludeFieldClasses);
         }
 
-        return Constants::EXCLUDED_FIELD_HANDLES;
+        return Constants::EXCLUDED_FIELD_CLASSES;
     }
 
     /**

--- a/tests/queryApiCollection/relatedToQueries/andNotRelatedTo.bru
+++ b/tests/queryApiCollection/relatedToQueries/andNotRelatedTo.bru
@@ -1,0 +1,28 @@
+meta {
+  name: andNotRelatedTo
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=1519&andNotRelatedTo=1521&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: 1519
+  andNotRelatedTo: 1521
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1521])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/andRelatedTo.bru
+++ b/tests/queryApiCollection/relatedToQueries/andRelatedTo.bru
@@ -1,0 +1,28 @@
+meta {
+  name: andRelatedTo
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=1519&andRelatedTo=1521&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: 1519
+  andRelatedTo: 1521
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1527])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/arrayWithAnd.bru
+++ b/tests/queryApiCollection/relatedToQueries/arrayWithAnd.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Array with AND
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=%5B%22and%22%2C1519%2C1521%5D&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: %5B%22and%22%2C1519%2C1521%5D
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1527])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/arrayWithOr.bru
+++ b/tests/queryApiCollection/relatedToQueries/arrayWithOr.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Array with OR
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=%5B%22or%22%2C1519%2C1521%5D&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: %5B%22or%22%2C1519%2C1521%5D
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1527, 1521, 1519])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/complexQuery.bru
+++ b/tests/queryApiCollection/relatedToQueries/complexQuery.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Complex Query
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=%5B%22and%22%2C%7B%22sE%22%3A1527%2C%22f%22%3A%22entries%22%7D%2C%5B%22not%22%2C1527%5D%5D&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: %5B%22and%22%2C%7B%22sE%22%3A1527%2C%22f%22%3A%22entries%22%7D%2C%5B%22not%22%2C1527%5D%5D
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1519, 1521])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/folder.bru
+++ b/tests/queryApiCollection/relatedToQueries/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Related To Queries
+  seq: 10
+}
+
+auth {
+  mode: inherit
+}

--- a/tests/queryApiCollection/relatedToQueries/notRelatedTo.bru
+++ b/tests/queryApiCollection/relatedToQueries/notRelatedTo.bru
@@ -17,6 +17,12 @@ params:query {
   all: 1
 }
 
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1521])
+}
+
 settings {
   encodeUrl: true
 }

--- a/tests/queryApiCollection/relatedToQueries/notRelatedTo.bru
+++ b/tests/queryApiCollection/relatedToQueries/notRelatedTo.bru
@@ -1,0 +1,22 @@
+meta {
+  name: notRelatedTo
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=1519&notRelatedTo=1521&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: 1519
+  notRelatedTo: 1521
+  all: 1
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/numeric.bru
+++ b/tests/queryApiCollection/relatedToQueries/numeric.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Numeric
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=1519&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: 1519
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1527, 1521])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/sourceElement.bru
+++ b/tests/queryApiCollection/relatedToQueries/sourceElement.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Source Element
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=%7B%22sE%22%3A1527%2C%22f%22%3A%22entries%22%7D&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: %7B%22sE%22%3A1527%2C%22f%22%3A%22entries%22%7D
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1519, 1521])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/sourceSite.bru
+++ b/tests/queryApiCollection/relatedToQueries/sourceSite.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Source Site
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=%5B%7B%22sS%22%3A%22en%22%2C%22tE%22%3A1519%7D%5D&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: %5B%7B%22sS%22%3A%22en%22%2C%22tE%22%3A1519%7D%5D
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1527, 1521])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/relatedToQueries/targetElement.bru
+++ b/tests/queryApiCollection/relatedToQueries/targetElement.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Target Element
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}?elementType=entries&relatedTo=%7B%22tE%22%3A1519%2C%22f%22%3A%22entries%22%7D&all=1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  elementType: entries
+  relatedTo: %7B%22tE%22%3A1519%2C%22f%22%3A%22entries%22%7D
+  all: 1
+}
+
+tests {
+  const helper = require('./tests');
+  
+  helper.isCorrectRespByIds([1527, 1521])
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tests/queryApiCollection/tests.js
+++ b/tests/queryApiCollection/tests.js
@@ -228,6 +228,21 @@ function isValidNestedByPaths(schema) {
   Object.entries(schema).forEach(([path, rule]) => assertPath(body, path, rule));
 }
 
+function isCorrectRespByIds(expectedIds) {
+  const resp = res.getBody();
+  const responseIds = resp.map(e => e.metadata.id).sort()
+  test(`${expectedIds.length} entries should be returned`, () => {
+    expect(responseIds.length).to.equal(expectedIds.length);
+  });
+
+  const responseIdSet = new Set(responseIds.map(String));
+  expectedIds.forEach(expectedId => {
+    test(`Should include "${expectedId}"`, () => {
+      expect(responseIdSet.has(String(expectedId)), `ID ${expectedId} is missing in response`).to.be.true;
+    });
+  });
+
+}
 
 module.exports = {
   isValidDataResp,
@@ -241,4 +256,5 @@ module.exports = {
   isValidMaxFieldSettingStructure,
   isValidAllRoutesResp,
   isValidNestedByPaths,
+  isCorrectRespByIds,
 }

--- a/tests/queryApiCollection/tests.js
+++ b/tests/queryApiCollection/tests.js
@@ -137,6 +137,7 @@ function isValidAllDefaultFieldsResp(isArr = false) {
     tags: [['metadata', 'title', 'slug'], true],
     time: [['date', 'timezone'], false],
     users: [reqKeys.users, true],
+    generatedField: [[], false, 'string'],
   }
   isValidNestedDataResp(properties, true)
 }

--- a/tests/typescript/generated-schemas.ts
+++ b/tests/typescript/generated-schemas.ts
@@ -423,6 +423,7 @@ export const craftEntryTypeDefaultFieldsSchema = z.object({
   tags: z.array(craftTagSchema).nullable(),
   time: craftDateTimeSchema.nullable(),
   users: z.array(craftUserSchema).nullable(),
+  generatedField: z.string(),
 });
 
 export const craftPageRelationalFieldsWithMaxSettingSchema =

--- a/tests/typescript/generated-schemas.ts
+++ b/tests/typescript/generated-schemas.ts
@@ -223,6 +223,17 @@ export const craftTableTableSchema = z.object({
   col2Handle: z.string(),
 });
 
+export const craftEntryTypeRelationsSchema = z.object({
+  title: z.string(),
+  entries: z.array(craftEntryRelationSchema).nullable(),
+});
+
+export const craftPageRelationsSchema = craftEntryTypeRelationsSchema.extend({
+  metadata: craftEntryMetaSchema,
+  title: z.string(),
+  sectionHandle: z.string(),
+});
+
 export const craftCategoryBlogFiltersSchema = z.object({
   title: z.string(),
   plainText: z.string().nullable(),

--- a/tests/typescript/generated-types.ts
+++ b/tests/typescript/generated-types.ts
@@ -248,6 +248,7 @@ export interface CraftEntryTypeDefaultFields {
     tags: (CraftTag)[] | null
     time: CraftDateTime | null
     users: (CraftUser)[] | null
+    generatedField: string
 }
 
 export interface CraftEntryTypeRelationalFieldsWithMaxSetting {

--- a/tests/typescript/generated-types.ts
+++ b/tests/typescript/generated-types.ts
@@ -261,6 +261,11 @@ export interface CraftEntryTypeRelationalFieldsWithMaxSetting {
     matrixMaxRelations: CraftEntryTypeRelationalFieldsWithMaxSetting | null
 }
 
+export interface CraftEntryTypeRelations {
+    title: string
+    entries: (CraftEntryRelation)[] | null
+}
+
 export interface CraftPageHome extends CraftEntryTypeHome {
     metadata: CraftEntryMeta
     title: string
@@ -274,6 +279,12 @@ export interface CraftPageDefaultFields extends CraftEntryTypeDefaultFields {
 }
 
 export interface CraftPageRelationalFieldsWithMaxSetting extends CraftEntryTypeRelationalFieldsWithMaxSetting {
+    metadata: CraftEntryMeta
+    title: string
+    sectionHandle: string
+}
+
+export interface CraftPageRelations extends CraftEntryTypeRelations {
     metadata: CraftEntryMeta
     title: string
     sectionHandle: string


### PR DESCRIPTION
## 3.5.0 - 2025-09-28

### Added

- Add support for `relatedTo` entry queries. #27 
- Add support for `andRelatedTo` entry queries. #27 
- Add support for `notRelated` entry queries. #27
- Add support for `andNotRelatedTo` entry queries. #27 
- Add generated fields to response and types. #28 

### Fixed
- Fixes caching issues in plugin development.